### PR TITLE
✨ Add terraform-docs pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,20 +19,22 @@ repos:
         args: ["."]
       - id: trivyconfig-docker
         args: ["."]
-  #  - repo: https://github.com/terraform-docs/terraform-docs
-  #    rev: v0.16.0
-  #    hooks:
-  #      - id: terraform-docs-system
-  #        args:
-  #          [
-  #            "markdown",
-  #            "--output-file",
-  #            "README.md",
-  #            "--hide-empty",
-  #            "--indent",
-  #            "3",
-  #            ".",
-  #          ]
+  - repo: https://github.com/terraform-docs/terraform-docs
+    rev: v0.24.0
+    hooks:
+      # -go variant matches the existing gruntwork golang-based hooks above; contributors
+      # already need Go on $PATH for terratest. Switch to -system or -docker if that changes.
+      - id: terraform-docs-go
+        args:
+          [
+            "markdown",
+            "table",
+            "--output-file",
+            "README.md",
+            "--output-mode",
+            "inject",
+            ".",
+          ]
 
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: "f12edd9c7be1c20cfa42420fd0e6df71e42b51ea" # frozen: v4.0.0-alpha.8


### PR DESCRIPTION
## Summary

Adds the upstream `terraform-docs-go` hook (v0.24.0) to `.pre-commit-config.yaml` so the README inputs/outputs tables auto-regenerate on every commit that touches `variables.tf` / `outputs.tf`.

## Context

Mirrors the canonical config landed in `bendoerr-terraform-modules/terraform-aws-defaults#238` (`f022126565`). Part of the cross-org sweep tracked in `bendoerr-terraform-modules/terraform-aws-defaults#237` — Ben greenlit the sweep, and this is one of 8 sister PRs (3 fresh inserts + 5 enabling a previously commented-out block).

## Changes

- `.pre-commit-config.yaml`: replace-commented the canonical terraform-docs hook block.
  - Pinned to `v0.24.0` (current upstream latest)
  - `-go` variant matches the existing gruntwork golang-based hooks; this repo's contributors already need Go on `$PATH` for terratest
  - Ordered **before** prettier so prettier reformats the regenerated table

## Notes

- Not for self-merge — leaving open for sober-Ben review in the morning.
- If `-go` doesn't work for this repo's contributor base, swap to `-system` or `-docker` (variants documented inline in the hook block comment).

🤖 Generated by code-kitten.